### PR TITLE
Include resources and xref search wildcards to the CopyFiles@2 command.

### DIFF
--- a/CI-CD/Pipeline-Samples/xpp-ci.yml
+++ b/CI-CD/Pipeline-Samples/xpp-ci.yml
@@ -50,7 +50,10 @@ steps:
   displayName: 'Copy Binary Dependencies to: $(Build.BinariesDirectory)'
   inputs:
     SourceFolder: '$(MetadataPath)'
-    Contents: '**/bin/**'
+    Contents: |
+      **/bin/**
+      **/Resources/**
+      **/*.xref
     TargetFolder: '$(Build.BinariesDirectory)'
 
 # Build using MSBuild 15 (VS 2017)


### PR DESCRIPTION
In case the ISV binary package contains resources (also known as label file information) or when there are cross-reference files present, we may include them by extending the list of the search wildcard for the copy files command.
We had to do this as the label information was not copied over by the original provided sample.