### PR TITLE
fix pipeline example

### DIFF
--- a/CI-CD/Pipeline-Samples/xpp-ci.yml
+++ b/CI-CD/Pipeline-Samples/xpp-ci.yml
@@ -10,9 +10,6 @@ trigger:
 pool:
 # Use the VS2019 image
   vmImage: 'windows-2019'
-  demands:
-    - msbuild
-    - visualstudio
   
 # Declare some shorthand for NuGet package names
 # Make editing the path for metadata and NuGet extraction folder easier
@@ -86,4 +83,5 @@ steps:
   inputs:
     PathtoPublish: '$(build.artifactstagingdirectory)'
   condition: succeededOrFailed()
+
 


### PR DESCRIPTION
This example doesn't work anymore because AzDo will fail (`Could not find a pool with name Hosted Windows 2019 with VS2019`), but it looks like all those requirements are present by default on windows2019 hosts now